### PR TITLE
Added parameters default values for service config

### DIFF
--- a/DependencyInjection/RollerworksPasswordStrengthExtension.php
+++ b/DependencyInjection/RollerworksPasswordStrengthExtension.php
@@ -30,6 +30,9 @@ class RollerworksPasswordStrengthExtension extends Extension
         $configuration = new Configuration();
         $config        = $this->processConfiguration($configuration, $configs);
 
+        $container->setParameter('rollerworks_password_strength.blacklist_provider', $config['blacklist']['default_provider']);
+        $container->setParameter('rollerworks_password_strength.blacklist.sqlite.dsn', '');
+
         $container->setAlias('rollerworks_password_strength.blacklist_provider', $config['blacklist']['default_provider']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));


### PR DESCRIPTION
Symfony 2.2, php 5.4
W/o existense of next parameters cannot use this bundle

  [Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException]
  The service "rollerworks_password_strength.blacklist.provider.sqlite" has a dependency on a non-existent parameter "rollerworks_password_strength.blacklist.sqlite.dsn".

  [Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException]
  The service "rollerworks_password_strength.blacklist.validator" has a dependency on a non-existent parameter "rollerworks_password_strength.blacklist_provider".
