### PR TITLE
Ignore validation if password is empty

### DIFF
--- a/src/Rollerworks/Bundle/PasswordStrengthBundle/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Rollerworks/Bundle/PasswordStrengthBundle/Validator/Constraints/PasswordStrengthValidator.php
@@ -43,6 +43,10 @@ class PasswordStrengthValidator extends ConstraintValidator
      */
     public function validate($password, Constraint $constraint)
     {
+        if (null === $password || '' === $password) {
+            return;
+        }
+
         if (null !== $password && !is_scalar($password) && !(is_object($password) && method_exists($password, '__toString'))) {
             throw new UnexpectedTypeException($password, 'string');
         }

--- a/tests/Rollerworks/Bundle/PasswordStrengthBundle/Tests/Validator/PasswordStrengthTest.php
+++ b/tests/Rollerworks/Bundle/PasswordStrengthBundle/Tests/Validator/PasswordStrengthTest.php
@@ -43,7 +43,7 @@ class PasswordStrengthTest extends \PHPUnit_Framework_TestCase
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->once())
+        $this->context->expects($this->never())
             ->method('addViolation');
 
         $this->validator->validate(null, new PasswordStrength(6));
@@ -51,7 +51,7 @@ class PasswordStrengthTest extends \PHPUnit_Framework_TestCase
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->once())
+        $this->context->expects($this->never())
             ->method('addViolation');
 
         $this->validator->validate('', new PasswordStrength(6));


### PR DESCRIPTION
If password is empty and not required (eg: In FOSUserBundle, plainPassword, is not required in "Profile", "ChangePassword" and "ResetPassword" groups), the validation must be ignored.

If password must be required, the Symfony\Component\Validator\Constraints\NotBlank validator must be used.
