### PR TITLE
Update PasswordStrengthValidator.php

### DIFF
--- a/src/Rollerworks/Bundle/PasswordStrengthBundle/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Rollerworks/Bundle/PasswordStrengthBundle/Validator/Constraints/PasswordStrengthValidator.php
@@ -78,7 +78,7 @@ class PasswordStrengthValidator extends ConstraintValidator
             $passwordStrength++;
         }
 
-        if (preg_match('/.[^a-zA-Z0-9]/', $password)) {
+        if (preg_match('/[^a-zA-Z0-9]/', $password)) {
             $specialChar = true;
             $passwordStrength++;
         }


### PR DESCRIPTION
Is it intened to use a dot in this regexp? Does the special char at the beginning of the password should be ignored?
