### PR TITLE
fix minimum symfony/validator version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=5.3.3",
         "symfony/framework-bundle": "^2.3.3",
         "symfony/console": "^2.3.3",
-        "symfony/validator": "^2.3.19"
+        "symfony/validator": "^2.3.20"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4"


### PR DESCRIPTION
buildViolation() was introduced in 2.3.20