### PR TITLE
Update PasswordRequirementsValidator.php

### DIFF
--- a/src/Validator/Constraints/PasswordRequirementsValidator.php
+++ b/src/Validator/Constraints/PasswordRequirementsValidator.php
@@ -69,7 +69,7 @@ class PasswordRequirementsValidator extends ConstraintValidator
         }
 
         if ($constraint->requireSpecialCharacter &&
-            !preg_match('/[^p{Ll}\p{Lu}\pL]/', $value)
+            !preg_match('/[^p{Ll}\p{Lu}\pL\pN]/', $value)
         ) {
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->missingSpecialCharacterMessage)


### PR DESCRIPTION
requireSpecialCharacter regex will currently match against numeric characters, added numeric to the list of excluded matches in the regex.