### PR TITLE
Fix: Use minLength as correct minimum for passwordStrength calculation

### DIFF
--- a/src/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Validator/Constraints/PasswordStrengthValidator.php
@@ -70,7 +70,7 @@ class PasswordStrengthValidator extends ConstraintValidator
 
         $alpha = $digit = $specialChar = false;
 
-        if ($passLength > $constraint->minLength) {
+        if ($passLength >= $constraint->minLength) {
             $passwordStrength++;
         }
 


### PR DESCRIPTION
The minLength appears to be used in two different ways:

For length validation:
password has to be equal or bigger than minLength

For strength validation:
password has to be bigger than minLength

This way the password will not validate if it has exactly the minLength and does exactly meet the other strength requirements. E.g.:
Password validation with minLength = 8 and minStrength = 3:
Test1234 will not validate (even though length is 8, there is a uppercase and lowercase character and there is a digit).
Test12345 will validate (because password is bigger than the required 8 characters).

This is why i've changed the passLength check in the passwordStrenght calculation of the validate function, so exactly the minimum length will result in an extra strength point. I think this is more like it is intended to be, but correct me if i'm wrong :)