### PR TITLE
Fix: Password strength calculation made easier and more consistent

### DIFF
--- a/docs/strength-validation.md
+++ b/docs/strength-validation.md
@@ -14,6 +14,16 @@ length and usage of (special) characters.
 **Note:** A strength is measured by the presence of a character and total length.
 One can have a 'medium' password consisting of only a-z and A-Z, but with a length higher than 12 characters.
 
+The strength is calculated using the following rules:
+
+* Does the password contain an alpha character?
+* Does the password contain both lowercase and uppercase alpha characters?
+* Does the password contain a digit?
+* Does the password contain a special character?
+* Does the password have a length of at least 13 characters.
+
+Each of these rules will add 1 point to the password strength. The minimum strength is 1 and the maximum strength is 5.
+
 If the password consists of only numbers or a-z/A-Z the final strength decreases.
 
 The strengths are listed as follows:

--- a/src/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Validator/Constraints/PasswordStrengthValidator.php
@@ -20,7 +20,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  * Password strength Validation.
  *
  * Validates if the password strength is equal or higher
- * to the required minimum.
+ * to the required minimum and the password length is equal
+ * or longer than the minimum length.
  *
  * The strength is computed from various measures including
  * length and usage of characters.
@@ -68,24 +69,18 @@ class PasswordStrengthValidator extends ConstraintValidator
             return;
         }
 
-        $alpha = $digit = $specialChar = false;
-
-        if ($passLength > $constraint->minLength) {
+        if (preg_match('/[a-zA-Z]/', $password)) {
             $passwordStrength++;
-        }
-
-        if (preg_match('/[a-z]/', $password) && preg_match('/[A-Z]/', $password)) {
-            $alpha = true;
-            $passwordStrength++;
+            if (preg_match('/[a-z]/', $password) && preg_match('/[A-Z]/', $password)) {
+                $passwordStrength++;
+            }
         }
 
         if (preg_match('/\d+/', $password)) {
-            $digit = true;
             $passwordStrength++;
         }
 
         if (preg_match('/[^a-zA-Z0-9]/', $password)) {
-            $specialChar = true;
             $passwordStrength++;
         }
 
@@ -94,13 +89,6 @@ class PasswordStrengthValidator extends ConstraintValidator
         }
 
         // No decrease strength on weak combinations
-
-        // Only digits no alpha or special char
-        if ($digit && !$alpha && !$specialChar) {
-            $passwordStrength--;
-        } elseif ($alpha && !$digit) {
-            $passwordStrength--;
-        }
 
         if ($passwordStrength < $constraint->minStrength) {
             if ($this->context instanceof ExecutionContextInterface) {

--- a/tests/Validator/PasswordStrengthTest.php
+++ b/tests/Validator/PasswordStrengthTest.php
@@ -53,11 +53,10 @@ class PasswordStrengthTest extends AbstractConstraintValidatorTest
     public static function getVeryWeakPasswords()
     {
         return array(
-            array('weak'),
-            array('foo'),
+            array('weaker'),
             array('123456'),
             array('foobar'),
-            array('foobar'),
+            array('!.!.!.'),
         );
     }
 
@@ -78,6 +77,8 @@ class PasswordStrengthTest extends AbstractConstraintValidatorTest
         return array(
             array('Foobar!'),
             array('foo-b0r!'),
+            array('fjsfjdljfsjsjjls1'),
+            array('785737592375294b'),
         );
     }
 
@@ -172,7 +173,7 @@ class PasswordStrengthTest extends AbstractConstraintValidatorTest
      */
     public function testVeryWeakPasswordWillNotPass($value)
     {
-        $constraint = new PasswordStrength(1);
+        $constraint = new PasswordStrength(2);
 
         $this->validator->validate($value, $constraint);
 
@@ -186,7 +187,7 @@ class PasswordStrengthTest extends AbstractConstraintValidatorTest
      */
     public function testWeakPasswordsWillNotPass($value)
     {
-        $constraint = new PasswordStrength(array(2));
+        $constraint = new PasswordStrength(3);
 
         $this->validator->validate($value, $constraint);
 
@@ -200,7 +201,7 @@ class PasswordStrengthTest extends AbstractConstraintValidatorTest
      */
     public function testMediumPasswordWillNotPass($value)
     {
-        $constraint = new PasswordStrength(array(3));
+        $constraint = new PasswordStrength(4);
 
         $this->validator->validate($value, $constraint);
 
@@ -214,7 +215,7 @@ class PasswordStrengthTest extends AbstractConstraintValidatorTest
      */
     public function testStrongPasswordWillNotPass($value)
     {
-        $constraint = new PasswordStrength(array(4));
+        $constraint = new PasswordStrength(5);
 
         $this->validator->validate($value, $constraint);
 


### PR DESCRIPTION
As mentioned in issue #46 here is the fix to make the strength calculation easier and more consistent. 

Basically there are are a 5 criteria that can make a password safe

    alpha character
    digit
    special character
    both lowercase and uppercase alpha character
    long password length (>12)

If you give a point when passing one of these criteria you get a minimum of 1 and a maximum of 5. No minus points are needed, and minimum length will already be enforced with the password length check.

Also the tests have been changed and fixed so the constraint matches the required test. 

