### PR TITLE
StyleCI / PHP-CS-Fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,19 @@
+<?php
+
+require_once __DIR__.'/vendor/sllh/php-cs-fixer-styleci-bridge/autoload.php';
+
+use SLLH\StyleCIBridge\ConfigBridge;
+use Symfony\CS\Fixer\Contrib\HeaderCommentFixer;
+
+$header = <<<EOF
+This file is part of the RollerworksPasswordStrengthBundle package.
+
+(c) Sebastiaan Stok <s.stok@rollerscapes.net>
+
+This source file is subject to the MIT license that is bundled
+with this source code in the file LICENSE.
+EOF;
+
+HeaderCommentFixer::setHeader($header);
+
+return ConfigBridge::create();

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,6 @@
+preset: symfony
+
+finder:
+  path:
+    - 'src/'
+    - 'tests/'

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "symfony/validator": "^2.3.20"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.4"
+        "phpunit/phpunit": "~4.4",
+        "sllh/php-cs-fixer-styleci-bridge": "^1.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This bridge permits developers to fix StyleCI issues on command line with php-cs-fixer tool or check it before make a PR.