### PR TITLE
Add I18n support for the validators

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,8 +22,4 @@
             <directory>./src</directory>
         </whitelist>
     </filter>
-
-    <php>
-        <ini name="mbstring.internal_encoding" value="UTF-8"/>
-    </php>
 </phpunit>

--- a/src/DependencyInjection/RollerworksPasswordStrengthExtension.php
+++ b/src/DependencyInjection/RollerworksPasswordStrengthExtension.php
@@ -36,6 +36,7 @@ class RollerworksPasswordStrengthExtension extends Extension
         $container->setAlias('rollerworks_password_strength.blacklist_provider', $config['blacklist']['default_provider']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('strength_validator.xml');
         $loader->load('blacklist.xml');
 
         if (isset($config['blacklist']['providers']['sqlite'])) {

--- a/src/Resources/config/strength_validator.xml
+++ b/src/Resources/config/strength_validator.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service class="Rollerworks\Bundle\PasswordStrengthBundle\Validator\Constraints\PasswordStrengthValidator" id="rollerworks_password_strength.validator.password_strength">
+            <argument id="translator" type="service" on-invalid="null" />
+            <tag name="validator.constraint_validator" alias="rollerworks_password_strength" />
+        </service>
+    </services>
+</container>

--- a/src/Resources/translations/validators.en.xlf
+++ b/src/Resources/translations/validators.en.xlf
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>Your password must be at least {{length}} characters long.</source>
+                <target>Password must be at least {{length}} characters long.</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>Your password must include at least one letter.</source>
+                <target>Password must include at least one letter.</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>Your password must include both upper and lower case letters.</source>
+                <target>Password must include both upper and lower case letters.</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>Your password must include at least one number.</source>
+                <target>Password must include at least one number.</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>Your password must contain at least one special character.</source>
+                <target>Password must contain at least one special character.</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>password_too_weak</source>
+                <target>Password needs to be at least at strength level "{{ min_strength }}", current level is "{{ current_strength }}", try the following {{ strength_tips }}.</target>
+            </trans-unit>
+
+            <!-- Strength levels -->
+            <trans-unit id="7">
+                <source>rollerworks_password.strength_level.very_weak</source>
+                <target>Very Weak</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>rollerworks_password.strength_level.weak</source>
+                <target>Weak</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>rollerworks_password.strength_level.medium</source>
+                <target>Medium</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>rollerworks_password.strength_level.strong</source>
+                <target>Strong</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>rollerworks_password.strength_level.very_strong</source>
+                <target>Very strong</target>
+            </trans-unit>
+
+            <!-- Tip translations -->
+            <trans-unit id="12">
+                <source>rollerworks_password.tip.letters</source>
+                <target>add (upper/lowercase) letters</target>
+            </trans-unit>
+            <trans-unit id="13">
+                <source>rollerworks_password.tip.numbers</source>
+                <target>add numbers</target>
+            </trans-unit>
+            <trans-unit id="14">
+                <source>rollerworks_password.tip.lowercase_letters</source>
+                <target>add uppercase letters</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>rollerworks_password.tip.uppercase_letters</source>
+                <target>add uppercase letters</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>rollerworks_password.tip.special_chars</source>
+                <target>add special characters</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>rollerworks_password.tip.length</source>
+                <target>add more characters</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Resources/translations/validators.nl.xlf
+++ b/src/Resources/translations/validators.nl.xlf
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>Your password must be at least {{length}} characters long.</source>
+                <target>Wachtwoord moet minstens {{length}} tekens lang zijn.</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>Your password must include at least one letter.</source>
+                <target>Wachtwoord moet ten minste één letter bevatten.</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>Your password must include both upper and lower case letters.</source>
+                <target>Wachtwoord moet ten minste één hoofdletter en kleine letter bevatten.</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>Your password must include at least one number.</source>
+                <target>Wachtwoord moet ten minste één nummer bevatten.</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>Your password must contain at least one special character.</source>
+                <target>Wachtwoord moet ten minste één speciaal teken of leesteken bevatten.</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>password_too_weak</source>
+                <target>Wachtwoord moet minstens aan sterkte niveau "{{ min_strength }}" voldoen, huidig niveau is “{{ current_strength }}” probeer het volgende: {{ strength_tips }}.</target>
+            </trans-unit>
+
+            <!-- Strength levels -->
+            <trans-unit id="7">
+                <source>rollerworks_password.strength_level.very_weak</source>
+                <target>Erg zwak</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>rollerworks_password.strength_level.weak</source>
+                <target>Zwak</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>rollerworks_password.strength_level.medium</source>
+                <target>Gemiddeld</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>rollerworks_password.strength_level.strong</source>
+                <target>Sterk</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>rollerworks_password.strength_level.very_strong</source>
+                <target>Zeer sterk</target>
+            </trans-unit>
+
+            <!-- Tip translations -->
+            <trans-unit id="12">
+                <source>rollerworks_password.tip.letters</source>
+                <target>voeg (hoofd/kleine) letters toe</target>
+            </trans-unit>
+            <trans-unit id="13">
+                <source>rollerworks_password.tip.numbers</source>
+                <target>voeg nummers toe</target>
+            </trans-unit>
+            <trans-unit id="14">
+                <source>rollerworks_password.tip.lowercase_letters</source>
+                <target>voeg hoofdletters toe</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>rollerworks_password.tip.uppercase_letters</source>
+                <target>voeg kleine letters toe</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>rollerworks_password.tip.special_chars</source>
+                <target>voeg speciaal tekens of leestekens toe</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>rollerworks_password.tip.length</source>
+                <target>gebruik meer tekens</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Validator/Constraints/PasswordStrength.php
+++ b/src/Validator/Constraints/PasswordStrength.php
@@ -34,4 +34,9 @@ class PasswordStrength extends Constraint
     {
         return array('minStrength');
     }
+
+    public function validatedBy()
+    {
+        return 'rollerworks_password_strength';
+    }
 }


### PR DESCRIPTION
|Q            |A          |
|---          |---        |
|Bug Fix?     |no         |
|New Feature? |yes        |
|BC Breaks?   |yes (minor)|
|Deprecations?|no         |
|Fixed Tickets|#27        |
|License      |MIT        |

There is a minor BC break for the translation strings (removed the 'Your' part from the translated string).