### PR TITLE
Forbid failures on PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,9 @@ matrix:
     include:
         - php: 5.3
           env: DEPENDENCIES='low'
-        - php: 5.6
+        - php: 7.0
           env: DEPENDENCIES='dev'
     allow_failures:
-        - php: 7.0
         - env: DEPENDENCIES='dev'
     fast_finish: true
 


### PR DESCRIPTION
The build against dev deps is also updated to use PHP 7.0, potentially allowing newer versions of deps.