### PR TITLE
Fix PasswordStrengthValidator length unicode chars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ cache:
     directories:
         - $HOME/.composer/cache
 
-#before_install:
-#    - composer selfupdate
+before_install:
+    - composer selfupdate
 
 install:
     - export COMPOSER_ROOT_VERSION=dev-master

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "php": ">=5.3.3",
         "symfony/framework-bundle": "^2.3.3|^3.0",
         "symfony/console": "^2.3.3|^3.0",
-        "symfony/validator": "^2.3.20|^3.0"
+        "symfony/validator": "^2.3.20|^3.0",
+        "symfony/polyfill-mbstring": "^1.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4|^5.2.9",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.4/phpunit.xsd"
+         backupGlobals="false"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
-         bootstrap="./tests/bootstrap.php"
-        >
+         bootstrap="vendor/autoload.php"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <ini name="date.timezone" value="UTC"/>
+        <ini name="intl.default_locale" value="en"/>
+        <ini name="intl.error_level" value="0"/>
+        <ini name="memory_limit" value="-1"/>
+        <ini name="mbstring.internal_encoding" value="UTF-8"/>
+    </php>
+
     <testsuites>
         <testsuite name="RollerworksPasswordStrengthBundle Test Suite">
             <directory>./tests</directory>

--- a/src/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Validator/Constraints/PasswordStrengthValidator.php
@@ -87,7 +87,7 @@ class PasswordStrengthValidator extends ConstraintValidator
         $password = (string) $password;
 
         $passwordStrength = 0;
-        $passLength = strlen($password);
+        $passLength = mb_strlen($password);
 
         if ($passLength < $constraint->minLength) {
             if ($this->context instanceof ExecutionContextInterface) {

--- a/tests/Validator/PasswordStrengthTest.php
+++ b/tests/Validator/PasswordStrengthTest.php
@@ -143,6 +143,21 @@ class PasswordStrengthTest extends AbstractConstraintValidatorTest
             ->assertRaised();
     }
 
+    public function testShortPasswordInMultiByteWillNotPass()
+    {
+        $constraint = new PasswordStrength(array('minStrength' => 5, 'minLength' => 7));
+
+        $this->validator->validate('foöled', $constraint);
+
+        $parameters = array(
+            '{{length}}' => 7,
+        );
+
+        $this->buildViolation('Your password must be at least {{length}} characters long.')
+            ->setParameters($parameters)
+            ->assertRaised();
+    }
+
     /**
      * @dataProvider getWeakPasswords
      */


### PR DESCRIPTION
Use `mb_strlen()` to ensure multi-byte characters are properly counted.