### PR TITLE
Speed-up travis build and other minor improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,23 @@
 language: php
 
-php:
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
-    - hhvm
-
 matrix:
     include:
+        # Use the newer stack for HHVM as HHVM does not support Precise anymore since a long time and so Precise has an outdated version
+        - php: hhvm-3.15
+          sudo: required
+          dist: trusty
+          group: edge
         - php: 5.3
-          env: DEPENDENCIES='low'
+          env: SKIP_OEL=true
+        - php: 5.4
+          env: SKIP_OEL=true
+        - php: 5.5
+          env: SKIP_OEL=true
+        - php: 5.6
         - php: 7.0
           env: DEPENDENCIES='dev'
-    allow_failures:
-        - env: DEPENDENCIES='dev'
+        - php: 7.1
+          env: DEPENDENCIES='low'
     fast_finish: true
 
 sudo: false
@@ -25,13 +27,18 @@ cache:
         - $HOME/.composer/cache
 
 before_install:
-    - composer selfupdate
+    # Matrix lines for OEL PHP versions are skipped for pull requests
+    - PHP=$TRAVIS_PHP_VERSION
+    - if [[ $SKIP_OEL && $TRAVIS_PULL_REQUEST != false ]]; then echo "Version ${PHP} is skipped for this pull request" && exit 0; fi
+    - if [[ ! $PHP = hhvm* ]]; then phpenv config-rm xdebug.ini || echo "xdebug not available"; fi
+    - composer selfupdate --stable
 
 install:
-    - export COMPOSER_ROOT_VERSION=dev-master
-    - if [ "$DEPENDENCIES" == "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
-    - if [ "$DEPENDENCIES" != "low" ]; then travis_retry composer update; fi;
-    - if [ "$DEPENDENCIES" == "low" ]; then travis_retry composer update --prefer-lowest; fi;
+    - export SYMFONY_PHPUNIT_REMOVE="symfony/yaml"
+    - export SYMFONY_DEPRECATIONS_HELPER=weak
+    - if [ "$DEPENDENCIES" == "dev" ]; then composer config minimum-stability dev; fi;
+    - if [ "$DEPENDENCIES" != "low" ]; then composer update --prefer-dist --no-progress --no-suggest --ansi; fi;
+    - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-dist --no-progress --no-suggest --ansi --prefer-lowest; fi;
 
 script:
-    - vendor/bin/phpunit --configuration phpunit.xml.dist
+    - vendor/bin/simple-phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "autoload": {
         "psr-4": {
             "Rollerworks\\Bundle\\PasswordStrengthBundle\\": "src/"
-        }
+        },
+        "exclude-from-classmap": ["test/"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/polyfill-mbstring": "^1.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.4|^5.2.9",
+        "symfony/phpunit-bridge": "^3.2",
         "sllh/php-cs-fixer-styleci-bridge": "^1.4",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.4",
         "matthiasnoback/symfony-service-definition-validator": "^1.2.2"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,5 +28,9 @@
         <whitelist>
             <directory>./src</directory>
         </whitelist>
+        <exclude>
+                <directory>./vendor/</directory>
+                <directory>./tests/</directory>
+            </exclude>
     </filter>
 </phpunit>


### PR DESCRIPTION
- Disable xdebug (no coverage used at the moment)
- Use Symfony phpunit-bridge (for the best PHPUnit version) and phpdbg on PHP 7
- Don’t run with OEL versions (in pull-requests)
- Add PHP 7.1 to testing matrix
- Use newer version of HHVM
- Exclude tests from class-map generation 