### PR TITLE
Add missing service definition to use the library constraint directly

### DIFF
--- a/src/Resources/config/strength_validator.xml
+++ b/src/Resources/config/strength_validator.xml
@@ -9,5 +9,10 @@
             <argument id="translator" type="service" on-invalid="null" />
             <tag name="validator.constraint_validator" alias="rollerworks_password_strength" />
         </service>
+
+        <service class="Rollerworks\Component\PasswordStrength\Validator\Constraints\PasswordStrengthValidator" id="rollerworks_password_strength.validator.password_strength.library">
+            <argument id="translator" type="service" on-invalid="null" />
+            <tag name="validator.constraint_validator" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT

When using the constraint from the library rather than from the bundle, we still need a service definition for the corresponding validator, otherwise it does not get the translator injected in it.
