### PR TITLE
Add PHP 7.4 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,15 @@ matrix:
             - SYMFONY_PHPUNIT_VERSION=8.3.5
         - php: 7.3
           env:
+            - SYMFONY_PHPUNIT_VERSION=8.3.5
+        - php: 7.4
+          env:
             - lint=1
             - SYMFONY_PHPUNIT_VERSION=8.3.5
-            - QA_DOCKER_IMAGE=jakzal/phpqa:1.25.0-php7.3-alpine
+            - QA_DOCKER_IMAGE=jakzal/phpqa:1.34.1-php7.4-alpine
           services:
               - docker
     fast_finish: true
-
-sudo: false
 
 cache:
     directories:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

- Add PHP 7.4 to Travis
- Remove `sudo: false` because this setting was deprecated (https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)
