### PR TITLE
Allow support for Symfony 8 (3.x branch)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,6 +27,11 @@ jobs:
                         php-version: '8.2'
                         composer-options: '--prefer-stable'
                         symfony-version: '^7.0'
+
+                    -
+                        php-version: '8.4'
+                        composer-options: '--prefer-stable'
+                        symfony-version: '^8.0'
         steps:
             -
                 name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
     "require": {
         "php": "^8.2",
         "rollerworks/password-strength-validator": "^2.0",
-        "symfony/framework-bundle": "^6.0 || ^7.0"
+        "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "^4.3.1 || ^5.0",
-        "phpunit/phpunit": "^9.5",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.3.1 || ^5.0 || ^6.2",
+        "phpunit/phpunit": "^9.5 || ^10.0",
         "rollerscapes/standards": "^1.0",
-        "symfony/phpunit-bridge": "^7.4"
+        "symfony/phpunit-bridge": "^7.4 || ^8.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/DependencyInjection/RollerworksPasswordStrengthExtension.php
+++ b/src/DependencyInjection/RollerworksPasswordStrengthExtension.php
@@ -16,14 +16,20 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 final class RollerworksPasswordStrengthExtension extends Extension implements PrependExtensionInterface
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
-        $loader->load('strength_validator.xml');
+        if (class_exists(XmlFileLoader::class)) {
+            $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+            $loader->load('strength_validator.xml');
+        } else {
+            $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+            $loader->load('strength_validator.php');
+        }
     }
 
     public function prepend(ContainerBuilder $container): void

--- a/src/Resources/config/strength_validator.php
+++ b/src/Resources/config/strength_validator.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksPasswordStrengthBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Rollerworks\Component\PasswordStrength\Validator\Constraints\PasswordStrengthValidator;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $container): void {
+    $di = $container->services();
+
+    $di->set(PasswordStrengthValidator::class)
+        ->args([service('translator')->nullOnInvalid()])
+        ->tag('validator.constraint_validator');
+};
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | 
| Fixed tickets | 
| License       | MIT

Add support for Symfony 8 in the 3.x branch. This will make upgrading easier.
Related to https://github.com/rollerworks/PasswordStrengthValidator/pull/75